### PR TITLE
Fix build: users of your library should not need to install grunt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 
 ## [Unreleased](https://github.com/idealista/tlsh-js/tree/develop)
 
+### Changed
+- *fixed build: users of your library should not need to install grunt (PR #16)* @dpoetzsch
+
 ## [1.0.6](https://github.com/idealista/tlsh-js/tree/1.0.6)
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tlsh",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -26,8 +26,7 @@
     "expect.js": "^0.3.1"
   },
   "scripts": {
-    "preinstall": "npm install --ignore-scripts",
-    "postinstall": "grunt browserify",
+    "prepare": "grunt browserify",
     "test": "grunt test"
   }
 }


### PR DESCRIPTION
### Description of the Change

We have `tlsh-js` as a dependency but our builds fail because grunt is not installed (and should not have to be installed).

Instead, the published npm package should have already been built, no need to run browserify postinstall. I fixed the triggers accordingly.

### Benefits

We can install your awesome library.
No user of your library needs to install grunt.

### Possible Drawbacks

I don't see any.