### PR TITLE
v1.0.7 to master (the good one)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
 - '8'
+before_deploy: "npm install --ignore-scripts"
 deploy:
   provider: npm
   email: labs@idealista.com

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 
 ## [Unreleased](https://github.com/idealista/tlsh-js/tree/develop)
 
+### Changed
+- *fixed build: users of your library should not need to install grunt (PR #16)* @dpoetzsch
+
 ## [1.0.6](https://github.com/idealista/tlsh-js/tree/1.0.6)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 
 ## [Unreleased](https://github.com/idealista/tlsh-js/tree/develop)
 
-### Changed
-- *fixed build: users of your library should not need to install grunt (PR #16)* @dpoetzsch
+## [1.0.7](https://github.com/idealista/tlsh-js/tree/1.0.7)
+### Fixed
+- *[#16](https://github.com/idealista/tlsh-js/pull/16)fixed build: users of your library should not need to install grunt* @dpoetzsch
 
 ## [1.0.6](https://github.com/idealista/tlsh-js/tree/1.0.6)
-
 ### Changed
 - *updated grunt: 0.4.5 -> ^1.0.3* @johnhenry
 - *updated grunt-contrib-jshint: ~0.2.0 -> 2.0.0* @johnhenry
@@ -16,6 +16,5 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 - *updated grunt-browserify: 5.0.0 -> 5.3.0* @dortegau
 
 ## [1.0.5](https://github.com/idealista/tlsh-js/tree/1.0.5)
-
 ### Added
 - *First release* @dortegau

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 
 ## [1.0.7](https://github.com/idealista/tlsh-js/tree/1.0.7)
 ### Fixed
-- *[#16](https://github.com/idealista/tlsh-js/pull/16)fixed build: users of your library should not need to install grunt* @dpoetzsch
+- *[#14](https://github.com/idealista/tlsh-js/issues/14) Update browserify due to CVE-2018-16472 in transitive dependency (cached-path-relative)* @jnogol
+- *[#16](https://github.com/idealista/tlsh-js/pull/16) fixed build: users of your library should not need to install grunt* @dpoetzsch
 
 ## [1.0.6](https://github.com/idealista/tlsh-js/tree/1.0.6)
 ### Changed

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 # JavaScript port of TLSH (Trend Micro Locality Sensitive Hash)
 
 [![Build Status](https://travis-ci.org/idealista/tlsh-js.svg?branch=master)](https://travis-ci.org/idealista/tlsh-js)
+[![Total Downloads](https://img.shields.io/npm/dt/tlsh.svg)](https://www.npmjs.com/package/tlsh)
 
 TLSH is a fuzzy matching library designed by [Trend Micro](http://www.trendmicro.com) (Hosted in [GitHub](https://github.com/trendmicro/tlsh))
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tlsh",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -667,9 +667,9 @@
       }
     },
     "cached-path-relative": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/cached-path-relative/-/cached-path-relative-1.0.1.tgz",
-      "integrity": "sha1-0JxLUoAKpMB44t2BqGmqyQ0uVOc=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cached-path-relative/-/cached-path-relative-1.0.2.tgz",
+      "integrity": "sha512-5r2GqsoEb4qMTTN9J+WzXfjov+hjxT+j3u5K+kIVNIwAd99DLCJE9pBIMP1qVeybV6JiijL385Oz0DcYxfbOIg==",
       "dev": true
     },
     "camelcase": {
@@ -1596,12 +1596,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1616,17 +1618,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1743,7 +1748,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1755,6 +1761,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1769,6 +1776,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -1776,12 +1784,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -1800,6 +1810,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1880,7 +1891,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1892,6 +1904,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2013,6 +2026,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tlsh",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -26,8 +26,7 @@
     "expect.js": "^0.3.1"
   },
   "scripts": {
-    "preinstall": "npm install --ignore-scripts",
-    "postinstall": "grunt browserify",
+    "prepare": "grunt browserify",
     "test": "grunt test"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tlsh",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "JavaScript port of TLSH (Trend Locality Sensitive Hash)",
   "main": "lib/tlsh.js",
   "author": "idealista <labs@idealista.com> (http://www.idealista.com/labs/blog/)",
@@ -22,6 +22,7 @@
     "grunt-contrib-jshint": "2.0.0",
     "grunt-mocha-test": "^0.12.7",
     "grunt-browserify": "^5.3.0",
+    "cached-path-relative": ">=1.0.2",
     "mocha": "5.2.0",
     "expect.js": "^0.3.1"
   },


### PR DESCRIPTION
## Fixed
- *[#14](https://github.com/idealista/tlsh-js/issues/14) Update browserify due to CVE-2018-16472 in transitive dependency (cached-path-relative)* @jnogol
- *[#16](https://github.com/idealista/tlsh-js/pull/16) fixed build: users of your library should not need to install grunt* @dpoetzsch